### PR TITLE
[FEATURE] 질문 조회 API 스펙 변경 

### DIFF
--- a/src/main/java/com/smunity/server/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/smunity/server/domain/question/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package com.smunity.server.domain.question.controller;
 
+import com.smunity.server.domain.question.dto.QuestionReadResponseDto;
 import com.smunity.server.domain.question.dto.QuestionRequestDto;
 import com.smunity.server.domain.question.dto.QuestionResponseDto;
 import com.smunity.server.domain.question.service.QuestionCommandService;
@@ -26,8 +27,8 @@ public class QuestionController {
     private final QuestionCommandService questionCommandService;
 
     @GetMapping
-    public ResponseEntity<Page<QuestionResponseDto>> readQuestions(@ParameterObject @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<QuestionResponseDto> responseDtoPage = questionQueryService.readQuestions(pageable);
+    public ResponseEntity<Page<QuestionReadResponseDto>> readQuestions(@AuthMember Long memberId, @ParameterObject @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<QuestionReadResponseDto> responseDtoPage = questionQueryService.readQuestions(memberId, pageable);
         return ResponseEntity.ok(responseDtoPage);
     }
 
@@ -38,8 +39,8 @@ public class QuestionController {
     }
 
     @GetMapping("/{questionId}")
-    public ResponseEntity<QuestionResponseDto> readQuestion(@PathVariable Long questionId) {
-        QuestionResponseDto responseDto = questionQueryService.readQuestion(questionId);
+    public ResponseEntity<QuestionReadResponseDto> readQuestion(@AuthMember Long memberId, @PathVariable Long questionId) {
+        QuestionReadResponseDto responseDto = questionQueryService.readQuestion(memberId, questionId);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/smunity/server/domain/question/dto/QuestionReadResponseDto.java
+++ b/src/main/java/com/smunity/server/domain/question/dto/QuestionReadResponseDto.java
@@ -2,29 +2,36 @@ package com.smunity.server.domain.question.dto;
 
 import com.smunity.server.domain.question.entity.Question;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 
 @Builder
-public record QuestionResponseDto(
+public record QuestionReadResponseDto(
         Long id,
         String title,
         String content,
         String author,
+        boolean isAuthor,
         boolean answered,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
 
-    public static QuestionResponseDto from(Question question) {
-        return QuestionResponseDto.builder()
+    public static QuestionReadResponseDto of(Long memberId, Question question) {
+        return QuestionReadResponseDto.builder()
                 .id(question.getId())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .author(question.getAuthor())
+                .isAuthor(question.getIsAuthor(memberId))
                 .answered(question.getAnswered())
                 .createdAt(question.getCreatedAt())
                 .updatedAt(question.getUpdatedAt())
                 .build();
+    }
+
+    public static Page<QuestionReadResponseDto> of(Long memberId, Page<Question> questions) {
+        return questions.map(question -> of(memberId, question));
     }
 }

--- a/src/main/java/com/smunity/server/domain/question/entity/Question.java
+++ b/src/main/java/com/smunity/server/domain/question/entity/Question.java
@@ -54,6 +54,10 @@ public class Question extends BaseEntity {
         return anonymous ? "익명" : member.getName();
     }
 
+    public boolean getIsAuthor(Long memberId) {
+        return member.getId().equals(memberId);
+    }
+
     public boolean getAnswered() {
         return answer != null;
     }

--- a/src/main/java/com/smunity/server/domain/question/service/QuestionQueryService.java
+++ b/src/main/java/com/smunity/server/domain/question/service/QuestionQueryService.java
@@ -1,6 +1,6 @@
 package com.smunity.server.domain.question.service;
 
-import com.smunity.server.domain.question.dto.QuestionResponseDto;
+import com.smunity.server.domain.question.dto.QuestionReadResponseDto;
 import com.smunity.server.domain.question.entity.Question;
 import com.smunity.server.domain.question.repository.QuestionRepository;
 import com.smunity.server.global.exception.GeneralException;
@@ -18,14 +18,14 @@ public class QuestionQueryService {
 
     private final QuestionRepository questionRepository;
 
-    public Page<QuestionResponseDto> readQuestions(Pageable pageable) {
+    public Page<QuestionReadResponseDto> readQuestions(Long memberId, Pageable pageable) {
         Page<Question> questions = questionRepository.findAll(pageable);
-        return QuestionResponseDto.from(questions);
+        return QuestionReadResponseDto.of(memberId, questions);
     }
 
-    public QuestionResponseDto readQuestion(Long questionId) {
+    public QuestionReadResponseDto readQuestion(Long memberId, Long questionId) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.QUESTION_NOT_FOUND));
-        return QuestionResponseDto.from(question);
+        return QuestionReadResponseDto.of(memberId, question);
     }
 }


### PR DESCRIPTION
## 📚 개요
+ #88

## ✏️ 작업 내용
+ 질문 조회 API 스펙 변경 -> `isAuthor` 필드 추가

## 💡 주의 사항
+ 질문의 `memberId` 식별자 노출 시 보안 측면에서 문제
+ 서버에서 작성자 여부를 직접 판단 (`isAuthor` 필드 추가)
